### PR TITLE
Update link of Blinky Walkthrough Tutorial URL fixes issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An awesome list of [Nerves](http://nerves-project.org/) libraries and resources
   - [Infinity APS](https://github.com/infinity-aps) - A closed loop control system for people with type 1 diabetes!
 
 ## Tutorials
-- [Blinky walkthrough](https://cafecode.co/posts/getting-started-with-nerves-embedded-elixir-on-raspberry-pi-3/) - Thorough getting started blogpost
+- [Blinky walkthrough](https://cafecode.co/posts/getting-started-with-nerves/) - Thorough getting started blogpost
 - [Hook up a Sensor](http://www.carstenblock.org/post/project-excelsius/) - Get information about the world
 - [Wake UP!](http://www.grappendorf.net/projects/sunrise-alarm-clock/hardware.html) - Build a sunrise alarm clock
 


### PR DESCRIPTION
+ [x] As discussed in issue #5 this link has been updated.